### PR TITLE
Fix Random Genreation within miliseconds to microseconds

### DIFF
--- a/directive/generation_helper.c
+++ b/directive/generation_helper.c
@@ -18,7 +18,7 @@ uint64_t get_current_timestamp_MS()
 {
     struct timeval tv;
     gettimeofday(&tv, NULL);
-    return (tv.tv_sec * 1000ULL) + (tv.tv_usec / 1000ULL);
+    return (tv.tv_sec * 1000000ULL) + tv.tv_usec;
 }
 
 uint64_t rand64()


### PR DESCRIPTION
Fix Random Genreation within miliseconds to microseconds

Before change: 
<img width="820" height="433" alt="image" src="https://github.com/user-attachments/assets/bee80fdd-36ab-4770-9e1b-7dd64a5e5dab" />

After change: 
<img width="825" height="455" alt="image" src="https://github.com/user-attachments/assets/181fa80c-57c5-49e2-af89-edd4db68a35f" />


**NOTE**: The evidences provide above does not prove whether the duplication are not produces through the microsecond improvements. It does shows that it is still unique after the change. Proper test will be done in another PR to prove whether the microseconds remove duplicate ids being generated.